### PR TITLE
feat(patients): Se agrega lógica de manejo de número de expediente

### DIFF
--- a/src/main/java/edu/mx/unsis/unsiSmile/dtos/request/patients/PatientRequest.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/dtos/request/patients/PatientRequest.java
@@ -15,9 +15,6 @@ import java.time.LocalDate;
 @NoArgsConstructor
 @Builder
 public class PatientRequest {
-    @NotNull(message = "Admission date cannot be null")
-    private LocalDate admissionDate;
-
     @NotNull(message = "isMinor cannot be null")
     private Boolean isMinor;
 
@@ -46,6 +43,4 @@ public class PatientRequest {
     private Long religionId;
 
     private GuardianRequest guardian;
-
-    private Long fileNumber;
 }

--- a/src/main/java/edu/mx/unsis/unsiSmile/dtos/request/patients/PatientRequest.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/dtos/request/patients/PatientRequest.java
@@ -46,4 +46,6 @@ public class PatientRequest {
     private Long religionId;
 
     private GuardianRequest guardian;
+
+    private Long fileNumber;
 }

--- a/src/main/java/edu/mx/unsis/unsiSmile/dtos/response/medicalHistories/ClinicalHistoryCatalogResponse.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/dtos/response/medicalHistories/ClinicalHistoryCatalogResponse.java
@@ -19,7 +19,7 @@ public class ClinicalHistoryCatalogResponse {
 
     private String clinicalHistoryName;
 
-    private Long fileNumber;
+    private Long medicalRecordNumber;
 
     private LocalDateTime date;
 

--- a/src/main/java/edu/mx/unsis/unsiSmile/dtos/response/medicalHistories/ClinicalHistoryCatalogResponse.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/dtos/response/medicalHistories/ClinicalHistoryCatalogResponse.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Data
@@ -17,6 +18,10 @@ public class ClinicalHistoryCatalogResponse {
     private Long idClinicalHistoryCatalog;
 
     private String clinicalHistoryName;
+
+    private Long fileNumber;
+
+    private LocalDateTime date;
 
     List<FormSectionResponse> formSections;
 }

--- a/src/main/java/edu/mx/unsis/unsiSmile/dtos/response/patients/PatientResponse.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/dtos/response/patients/PatientResponse.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 public class PatientResponse {
     private UUID idPatient;
     private LocalDate admissionDate;
-    private Long fileNumber;
+    private Long medicalRecordNumber;
     private Boolean isMinor;
     private Boolean hasDisability;
     private NationalityResponse nationality;

--- a/src/main/java/edu/mx/unsis/unsiSmile/dtos/response/patients/PatientResponse.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/dtos/response/patients/PatientResponse.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 public class PatientResponse {
     private UUID idPatient;
     private LocalDate admissionDate;
+    private Long fileNumber;
     private Boolean isMinor;
     private Boolean hasDisability;
     private NationalityResponse nationality;

--- a/src/main/java/edu/mx/unsis/unsiSmile/mappers/medicalHistories/ClinicalHistoryCatalogMapper.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/mappers/medicalHistories/ClinicalHistoryCatalogMapper.java
@@ -25,6 +25,8 @@ public class ClinicalHistoryCatalogMapper implements BaseMapper<ClinicalHistoryC
         return ClinicalHistoryCatalogResponse.builder()
                 .idClinicalHistoryCatalog(entity.getIdClinicalHistoryCatalog())
                 .clinicalHistoryName(entity.getClinicalHistoryName())
+                .fileNumber(null)
+                .date(null)
                 .formSections(Collections.emptyList())
                 .build();
     }

--- a/src/main/java/edu/mx/unsis/unsiSmile/mappers/medicalHistories/ClinicalHistoryCatalogMapper.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/mappers/medicalHistories/ClinicalHistoryCatalogMapper.java
@@ -25,7 +25,7 @@ public class ClinicalHistoryCatalogMapper implements BaseMapper<ClinicalHistoryC
         return ClinicalHistoryCatalogResponse.builder()
                 .idClinicalHistoryCatalog(entity.getIdClinicalHistoryCatalog())
                 .clinicalHistoryName(entity.getClinicalHistoryName())
-                .fileNumber(null)
+                .medicalRecordNumber(null)
                 .date(null)
                 .formSections(Collections.emptyList())
                 .build();

--- a/src/main/java/edu/mx/unsis/unsiSmile/mappers/patients/PatientMapper.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/mappers/patients/PatientMapper.java
@@ -41,7 +41,7 @@ public class PatientMapper implements BaseMapper<PatientResponse, PatientRequest
                 .ethnicGroup(EthnicGroupModel.builder().idEthnicGroup(dto.getEthnicGroupId()).build())
                 .religion(ReligionModel.builder().idReligion(dto.getReligionId()).build())
                 .guardian(dto.getGuardian() != null ? guardianMapper.toEntity(dto.getGuardian()) : null)
-                .fileNumber(null)
+                .medicalRecordNumber(null)
                 .build();
     }
 
@@ -50,7 +50,7 @@ public class PatientMapper implements BaseMapper<PatientResponse, PatientRequest
         return PatientResponse.builder()
                 .idPatient(entity.getIdPatient())
                 .admissionDate(entity.getAdmissionDate())
-                .fileNumber(entity.getFileNumber())
+                .medicalRecordNumber(entity.getMedicalRecordNumber())
                 .isMinor(entity.getIsMinor())
                 .hasDisability(entity.getHasDisability())
                 .nationality(nationalityMapper.toDto(entity.getNationality()))

--- a/src/main/java/edu/mx/unsis/unsiSmile/mappers/patients/PatientMapper.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/mappers/patients/PatientMapper.java
@@ -10,6 +10,7 @@ import edu.mx.unsis.unsiSmile.model.patients.*;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Component;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,7 +30,7 @@ public class PatientMapper implements BaseMapper<PatientResponse, PatientRequest
     @Override
     public PatientModel toEntity(PatientRequest dto) {
         return PatientModel.builder()
-                .admissionDate(dto.getAdmissionDate())
+                .admissionDate(LocalDate.now())
                 .isMinor(dto.getIsMinor())
                 .hasDisability(dto.getHasDisability())
                 .nationality(NationalityModel.builder().idNationality(dto.getNationalityId()).build())
@@ -40,7 +41,7 @@ public class PatientMapper implements BaseMapper<PatientResponse, PatientRequest
                 .ethnicGroup(EthnicGroupModel.builder().idEthnicGroup(dto.getEthnicGroupId()).build())
                 .religion(ReligionModel.builder().idReligion(dto.getReligionId()).build())
                 .guardian(dto.getGuardian() != null ? guardianMapper.toEntity(dto.getGuardian()) : null)
-                .fileNumber(dto.getFileNumber())
+                .fileNumber(null)
                 .build();
     }
 
@@ -72,7 +73,7 @@ public class PatientMapper implements BaseMapper<PatientResponse, PatientRequest
 
     @Override
     public void updateEntity(PatientRequest request, PatientModel entity) {
-        entity.setAdmissionDate(request.getAdmissionDate());
+        entity.setAdmissionDate(LocalDate.now());
         entity.setIsMinor(request.getIsMinor());
         entity.setHasDisability(request.getHasDisability());
         entity.setNationality(NationalityModel.builder().idNationality(request.getNationalityId()).build());

--- a/src/main/java/edu/mx/unsis/unsiSmile/mappers/patients/PatientMapper.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/mappers/patients/PatientMapper.java
@@ -1,22 +1,17 @@
 package edu.mx.unsis.unsiSmile.mappers.patients;
 
-import java.util.List;
-import java.util.stream.Collectors;
-
-import org.springframework.stereotype.Component;
-
 import edu.mx.unsis.unsiSmile.dtos.request.patients.PatientRequest;
 import edu.mx.unsis.unsiSmile.dtos.response.patients.PatientResponse;
 import edu.mx.unsis.unsiSmile.mappers.BaseMapper;
 import edu.mx.unsis.unsiSmile.mappers.PersonMapper;
 import edu.mx.unsis.unsiSmile.mappers.addresses.AddressMapper;
 import edu.mx.unsis.unsiSmile.model.addresses.NationalityModel;
-import edu.mx.unsis.unsiSmile.model.patients.EthnicGroupModel;
-import edu.mx.unsis.unsiSmile.model.patients.MaritalStatusModel;
-import edu.mx.unsis.unsiSmile.model.patients.OccupationModel;
-import edu.mx.unsis.unsiSmile.model.patients.PatientModel;
-import edu.mx.unsis.unsiSmile.model.patients.ReligionModel;
+import edu.mx.unsis.unsiSmile.model.patients.*;
 import lombok.AllArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Component
 @AllArgsConstructor
@@ -45,6 +40,7 @@ public class PatientMapper implements BaseMapper<PatientResponse, PatientRequest
                 .ethnicGroup(EthnicGroupModel.builder().idEthnicGroup(dto.getEthnicGroupId()).build())
                 .religion(ReligionModel.builder().idReligion(dto.getReligionId()).build())
                 .guardian(dto.getGuardian() != null ? guardianMapper.toEntity(dto.getGuardian()) : null)
+                .fileNumber(dto.getFileNumber())
                 .build();
     }
 
@@ -53,6 +49,7 @@ public class PatientMapper implements BaseMapper<PatientResponse, PatientRequest
         return PatientResponse.builder()
                 .idPatient(entity.getIdPatient())
                 .admissionDate(entity.getAdmissionDate())
+                .fileNumber(entity.getFileNumber())
                 .isMinor(entity.getIsMinor())
                 .hasDisability(entity.getHasDisability())
                 .nationality(nationalityMapper.toDto(entity.getNationality()))

--- a/src/main/java/edu/mx/unsis/unsiSmile/model/patients/PatientModel.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/model/patients/PatientModel.java
@@ -68,6 +68,6 @@ public class PatientModel extends AuditModel {
     @JoinColumn(name = "fk_guardian", referencedColumnName = "id_guardian")
     private GuardianModel guardian;
 
-    @Column(name = "file_number", unique = true)
-    private Long fileNumber;
+    @Column(name = "medical_record_number", unique = true)
+    private Long medicalRecordNumber;
 }

--- a/src/main/java/edu/mx/unsis/unsiSmile/model/patients/PatientModel.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/model/patients/PatientModel.java
@@ -68,6 +68,6 @@ public class PatientModel extends AuditModel {
     @JoinColumn(name = "fk_guardian", referencedColumnName = "id_guardian")
     private GuardianModel guardian;
 
-    @Column(name = "file_number")
+    @Column(name = "file_number", unique = true)
     private Long fileNumber;
 }

--- a/src/main/java/edu/mx/unsis/unsiSmile/model/patients/PatientModel.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/model/patients/PatientModel.java
@@ -68,4 +68,6 @@ public class PatientModel extends AuditModel {
     @JoinColumn(name = "fk_guardian", referencedColumnName = "id_guardian")
     private GuardianModel guardian;
 
+    @Column(name = "file_number")
+    private Long fileNumber;
 }

--- a/src/main/java/edu/mx/unsis/unsiSmile/repository/patients/IPatientRepository.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/repository/patients/IPatientRepository.java
@@ -51,8 +51,8 @@ public interface IPatientRepository extends JpaRepository<PatientModel, UUID> {
             "AND p.statusKey = 'A'")
     Page<PatientModel> findAllBySearchInput(String keyword, Pageable pageable);
 
-    Optional<PatientModel> findByFileNumber(Long fileNumber);
+    Optional<PatientModel> findByMedicalRecordNumber(Long fileNumber);
 
-    @Query("SELECT MAX(fileNumber) FROM PatientModel")
+    @Query("SELECT MAX(medicalRecordNumber) FROM PatientModel")
     Long findMaxFileNumber();
 }

--- a/src/main/java/edu/mx/unsis/unsiSmile/repository/patients/IPatientRepository.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/repository/patients/IPatientRepository.java
@@ -50,4 +50,9 @@ public interface IPatientRepository extends JpaRepository<PatientModel, UUID> {
             "OR p.address.street.name LIKE %:keyword% " +
             "AND p.statusKey = 'A'")
     Page<PatientModel> findAllBySearchInput(String keyword, Pageable pageable);
+
+    Optional<PatientModel> findByFileNumber(Long fileNumber);
+
+    @Query("SELECT MAX(fileNumber) FROM PatientModel")
+    Long findMaxFileNumber();
 }

--- a/src/main/java/edu/mx/unsis/unsiSmile/service/medicalHistories/ClinicalHistoryCatalogService.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/service/medicalHistories/ClinicalHistoryCatalogService.java
@@ -115,7 +115,7 @@ public class ClinicalHistoryCatalogService {
 
         ClinicalHistoryCatalogResponse clinicalHistoryCatalogResponse = clinicalHistoryCatalogMapper.toDto(patientClinicalHistory.getClinicalHistoryCatalog());
 
-        clinicalHistoryCatalogResponse.setFileNumber(patientClinicalHistory.getPatient().getFileNumber());
+        clinicalHistoryCatalogResponse.setMedicalRecordNumber(patientClinicalHistory.getPatient().getMedicalRecordNumber());
         clinicalHistoryCatalogResponse.setDate(patientClinicalHistory.getDate());
 
         clinicalHistoryCatalogResponse.setFormSections(sections);

--- a/src/main/java/edu/mx/unsis/unsiSmile/service/medicalHistories/ClinicalHistoryCatalogService.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/service/medicalHistories/ClinicalHistoryCatalogService.java
@@ -56,7 +56,7 @@ public class ClinicalHistoryCatalogService {
             }
 
             Assert.notNull(idPatient, "Patient ID cannot be null");
-            if (idPatient.equals("0")) {
+            if ("0".equals(idPatient.toString())) {
                 throw new AppException("Patient ID cannot be 0", HttpStatus.BAD_REQUEST);
             }
 
@@ -115,6 +115,9 @@ public class ClinicalHistoryCatalogService {
 
         ClinicalHistoryCatalogResponse clinicalHistoryCatalogResponse = clinicalHistoryCatalogMapper.toDto(patientClinicalHistory.getClinicalHistoryCatalog());
 
+        clinicalHistoryCatalogResponse.setFileNumber(patientClinicalHistory.getPatient().getFileNumber());
+        clinicalHistoryCatalogResponse.setDate(patientClinicalHistory.getDate());
+
         clinicalHistoryCatalogResponse.setFormSections(sections);
 
         return clinicalHistoryCatalogResponse;
@@ -147,7 +150,7 @@ public class ClinicalHistoryCatalogService {
     }
 
     private UUID convertBytesToUUID(Object result) {
-        if (result == null || !(result instanceof byte[])) {
+        if (!(result instanceof byte[])) {
             return null;
         }
 

--- a/src/main/java/edu/mx/unsis/unsiSmile/service/medicalHistories/PatientClinicalHistoryService.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/service/medicalHistories/PatientClinicalHistoryService.java
@@ -2,7 +2,6 @@ package edu.mx.unsis.unsiSmile.service.medicalHistories;
 
 import edu.mx.unsis.unsiSmile.common.Constants;
 import edu.mx.unsis.unsiSmile.exceptions.AppException;
-import edu.mx.unsis.unsiSmile.mappers.medicalHistories.ClinicalHistoryCatalogMapper;
 import edu.mx.unsis.unsiSmile.model.ClinicalHistoryCatalogModel;
 import edu.mx.unsis.unsiSmile.model.PatientClinicalHistoryModel;
 import edu.mx.unsis.unsiSmile.model.patients.PatientModel;
@@ -121,6 +120,7 @@ public class PatientClinicalHistoryService {
                 .idPatientClinicalHistory(entity.getIdPatientClinicalHistory())
                 .patient(entity.getPatient())
                 .clinicalHistoryCatalog(entity.getClinicalHistoryCatalog())
+                .date(entity.getDate())
                 .build();
     }
 }

--- a/src/main/java/edu/mx/unsis/unsiSmile/service/patients/PatientService.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/service/patients/PatientService.java
@@ -69,22 +69,6 @@ public class PatientService {
     @Transactional
     public void createPatient(@Valid @NonNull PatientRequest patientRequest) {
         try {
-            if (patientRequest.getFileNumber() == null || patientRequest.getFileNumber() == 0) {
-
-                long maxFileNumber = Optional.ofNullable(patientRepository.findMaxFileNumber()).orElse(0L);
-
-                if (maxFileNumber < maxFileNumberProperties) {
-                    patientRequest.setFileNumber((long) maxFileNumberProperties);
-                } else {
-                    patientRequest.setFileNumber(maxFileNumber + 1);
-                }
-            } else {
-                Optional<PatientModel> existingFolio = patientRepository.findByFileNumber(patientRequest.getFileNumber());
-                if (existingFolio.isPresent()) {
-                    throw new AppException("The provided folio already exists: " + patientRequest.getFileNumber(), HttpStatus.CONFLICT);
-                }
-            }
-
             PersonModel person = createPersonEntity(patientRequest.getPerson());
             PatientModel patientModel = preparePatientModel(patientRequest, person);
             validateAndSetGuardian(patientRequest, patientModel);
@@ -112,7 +96,16 @@ public class PatientService {
     }
 
     private PatientModel preparePatientModel(PatientRequest patientRequest, PersonModel person) {
+        long maxFileNumber = Optional.ofNullable(patientRepository.findMaxFileNumber()).orElse(0L);
+
         PatientModel patientModel = patientMapper.toEntity(patientRequest);
+
+        if (maxFileNumber < maxFileNumberProperties) {
+            patientModel.setFileNumber((long) maxFileNumberProperties);
+        } else {
+            patientModel.setFileNumber(maxFileNumber + 1);
+        }
+
         patientModel.setPerson(person);
         return patientModel;
     }

--- a/src/main/java/edu/mx/unsis/unsiSmile/service/patients/PatientService.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/service/patients/PatientService.java
@@ -63,7 +63,7 @@ public class PatientService {
     private final StudentPatientService studentPatientService;
     private final StudentService studentService;
     private final PersonService personService;
-    @Value("${file.max.number}")
+    @Value("${max.medical.record.number}")
     private int maxFileNumberProperties;
 
     @Transactional
@@ -96,14 +96,14 @@ public class PatientService {
     }
 
     private PatientModel preparePatientModel(PatientRequest patientRequest, PersonModel person) {
-        long maxFileNumber = Optional.ofNullable(patientRepository.findMaxFileNumber()).orElse(0L);
+        long maxMedicalRecordNumber = Optional.ofNullable(patientRepository.findMaxFileNumber()).orElse(0L);
 
         PatientModel patientModel = patientMapper.toEntity(patientRequest);
 
-        if (maxFileNumber < maxFileNumberProperties) {
-            patientModel.setFileNumber((long) maxFileNumberProperties);
+        if (maxMedicalRecordNumber < maxFileNumberProperties) {
+            patientModel.setMedicalRecordNumber((long) maxFileNumberProperties);
         } else {
-            patientModel.setFileNumber(maxFileNumber + 1);
+            patientModel.setMedicalRecordNumber(maxMedicalRecordNumber + 1);
         }
 
         patientModel.setPerson(person);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,3 +26,5 @@ spring.servlet.multipart.max-request-size=50MB
 
 #app data
 api.uris.download.files=https://unsismile-back.unsis.edu.mx/unsismile/api/v1/files/file/
+
+file.max.number=${FILE_MAX_NUMBER:5}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -27,4 +27,4 @@ spring.servlet.multipart.max-request-size=50MB
 #app data
 api.uris.download.files=https://unsismile-back.unsis.edu.mx/unsismile/api/v1/files/file/
 
-file.max.number=${FILE_MAX_NUMBER:5}
+max.medical.record.number=${MAX_MEDICAL_RECORD_NUMBER:3}

--- a/src/main/resources/db/migration/V0.0.2__changelog.sql
+++ b/src/main/resources/db/migration/V0.0.2__changelog.sql
@@ -183,7 +183,7 @@ CREATE TABLE patients (
                           admission_date DATE DEFAULT NULL,
                           has_disability BIT(1) DEFAULT NULL,
                           is_minor BIT(1) DEFAULT NULL,
-                          file_number BIGINT(20),
+                          medical_record_number BIGINT(20),
                           fk_address BIGINT(20) NOT NULL,
                           fk_ethnic_group BIGINT(20) DEFAULT NULL,
                           fk_guardian BIGINT(20) DEFAULT NULL,

--- a/src/main/resources/db/migration/V0.0.2__changelog.sql
+++ b/src/main/resources/db/migration/V0.0.2__changelog.sql
@@ -183,6 +183,7 @@ CREATE TABLE patients (
                           admission_date DATE DEFAULT NULL,
                           has_disability BIT(1) DEFAULT NULL,
                           is_minor BIT(1) DEFAULT NULL,
+                          file_number BIGINT(20),
                           fk_address BIGINT(20) NOT NULL,
                           fk_ethnic_group BIGINT(20) DEFAULT NULL,
                           fk_guardian BIGINT(20) DEFAULT NULL,


### PR DESCRIPTION
- Implementada la lógica para gestionar el número de expediente en PatientRequest y PatientResponse.
- Actualizados PatientModel, PatientMapper y repository para manejo del número de expediente.
- Añadida la variable de límite para el número de expediente en application.properties.
- Agregado el atributo número de expediente en el script para la migración.

Al crear un paciente, se agrega el número de su expediente 
![image](https://github.com/user-attachments/assets/61750596-497d-428b-863a-5566ca4f4fcb)
al hacer una consulta sobre pacientes, se devuelve también su # de expediente
![image](https://github.com/user-attachments/assets/fd52e1da-5969-44df-a1b9-3a118a61882c)
