### PR TITLE
feat: Se cambia la estructura de respuesta y la lógica de mapeo de lo…

### DIFF
--- a/src/main/java/edu/mx/unsis/unsiSmile/controller/medicalHistories/treatments/TreatmentDetailController.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/controller/medicalHistories/treatments/TreatmentDetailController.java
@@ -85,8 +85,8 @@ public class TreatmentDetailController {
             @RequestParam(required = false) Long idTreatment,
             @RequestParam(defaultValue = "0") int page,
             @RequestParam(defaultValue = "10") int size,
-            @Parameter(description = "Field key for ordering", example = "idTreatmentDetail")
-            @RequestParam(defaultValue = "idTreatmentDetail") String order,
+            @Parameter(description = "Field key for ordering", example = "createdAt")
+            @RequestParam(defaultValue = "createdAt") String order,
             @RequestParam(defaultValue = "false") boolean asc) {
 
         Sort sort = asc ? Sort.by(order).ascending() : Sort.by(order).descending();

--- a/src/main/java/edu/mx/unsis/unsiSmile/dtos/response/medicalHistories/treatments/TreatmentDetailResponse.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/dtos/response/medicalHistories/treatments/TreatmentDetailResponse.java
@@ -33,6 +33,7 @@ public class TreatmentDetailResponse {
     public static class PatientResponse {
         private String id;
         private String name;
+        private Long medicalRecordNumber;
         private Long idPatientMedicalRecord;
     }
 

--- a/src/main/java/edu/mx/unsis/unsiSmile/dtos/response/medicalHistories/treatments/TreatmentDetailResponse.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/dtos/response/medicalHistories/treatments/TreatmentDetailResponse.java
@@ -15,16 +15,44 @@ import java.util.List;
 public class TreatmentDetailResponse {
 
     private Long idTreatmentDetail;
-    private Long patientClinicalHistoryId;
-    private String patientId;
-    private String patientName;
-    private TreatmentResponse treatment;
-    List<TreatmentDetailToothResponse> teeth;
     private LocalDateTime startDate;
     private LocalDateTime endDate;
-    private Long studentGroupId;
-    private String professorId;
-    private String professorName;
-    private String studentName;
     private String status;
+
+    private PatientResponse patient;
+    private ProfessorResponse professor;
+    private StudentResponse student;
+
+    private TreatmentResponse treatment;
+    private List<TreatmentDetailToothResponse> teeth;
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class PatientResponse {
+        private String id;
+        private String name;
+        private Long idPatientMedicalRecord;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ProfessorResponse {
+        private String id;
+        private String name;
+    }
+
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class StudentResponse {
+        private String id;
+        private String name;
+        private Long idGroup;
+        private String group;
+    }
 }

--- a/src/main/java/edu/mx/unsis/unsiSmile/mappers/medicalHistories/treatments/TreatmentDetailMapper.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/mappers/medicalHistories/treatments/TreatmentDetailMapper.java
@@ -43,6 +43,7 @@ public class TreatmentDetailMapper implements BaseMapper<TreatmentDetailResponse
                 .patient(TreatmentDetailResponse.PatientResponse.builder()
                         .id(entity.getPatientClinicalHistory().getPatient().getIdPatient())
                         .name(entity.getPatientClinicalHistory().getPatient().getPerson().getFullName())
+                        .medicalRecordNumber(entity.getPatientClinicalHistory().getPatient().getMedicalRecordNumber())
                         .idPatientMedicalRecord(entity.getPatientClinicalHistory().getIdPatientClinicalHistory())
                         .build())
                 .professor(entity.getProfessor() != null ?

--- a/src/main/java/edu/mx/unsis/unsiSmile/mappers/medicalHistories/treatments/TreatmentDetailMapper.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/mappers/medicalHistories/treatments/TreatmentDetailMapper.java
@@ -36,15 +36,29 @@ public class TreatmentDetailMapper implements BaseMapper<TreatmentDetailResponse
     public TreatmentDetailResponse toDto(TreatmentDetailModel entity) {
         return TreatmentDetailResponse.builder()
                 .idTreatmentDetail(entity.getIdTreatmentDetail())
-                .patientClinicalHistoryId(entity.getPatientClinicalHistory().getIdPatientClinicalHistory())
-                .treatment(treatmentMapper.toDto(entity.getTreatment()))
                 .startDate(entity.getStartDate())
                 .endDate(entity.getEndDate())
-                .studentGroupId(entity.getStudentGroup().getIdStudentGroups())
-                .professorId(entity.getProfessor() != null ?
-                        entity.getProfessor().getIdProfessor() : null)
                 .status(entity.getStatus())
-                .patientId(entity.getPatientClinicalHistory().getPatient().getIdPatient())
+                .treatment(treatmentMapper.toDto(entity.getTreatment()))
+                .patient(TreatmentDetailResponse.PatientResponse.builder()
+                        .id(entity.getPatientClinicalHistory().getPatient().getIdPatient())
+                        .name(entity.getPatientClinicalHistory().getPatient().getPerson().getFullName())
+                        .idPatientMedicalRecord(entity.getPatientClinicalHistory().getIdPatientClinicalHistory())
+                        .build())
+                .professor(entity.getProfessor() != null ?
+                        TreatmentDetailResponse.ProfessorResponse.builder()
+                                .id(entity.getProfessor().getIdProfessor())
+                                .name(entity.getProfessor().getPerson().getFullName())
+                                .build() :
+                        null)
+                .student(entity.getStudentGroup() != null ?
+                        TreatmentDetailResponse.StudentResponse.builder()
+                                .id(entity.getStudentGroup().getStudent().getEnrollment())
+                                .name(entity.getStudentGroup().getStudent().getPerson().getFullName())
+                                .group(entity.getStudentGroup().getGroup().getGroupName())
+                                .idGroup(entity.getStudentGroup().getGroup().getIdGroup())
+                                .build() :
+                        null)
                 .build();
     }
 

--- a/src/main/java/edu/mx/unsis/unsiSmile/mappers/medicalHistories/treatments/TreatmentMapper.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/mappers/medicalHistories/treatments/TreatmentMapper.java
@@ -39,7 +39,7 @@ public class TreatmentMapper implements BaseMapper<TreatmentResponse, TreatmentR
                 .idTreatment(entity.getIdTreatment())
                 .name(entity.getName())
                 .treatmentScope(treatmentScopeMapper.toDto(entity.getTreatmentScope()))
-                .cost(entity.getCost())
+                .cost(entity.getCost() != null ? entity.getCost() : BigDecimal.ZERO)
                 .clinicalHistoryCatalogId(entity.getClinicalHistoryCatalog() != null ?
                         entity.getClinicalHistoryCatalog().getIdClinicalHistoryCatalog() : null)
                 .clinicalHistoryCatalogName(entity.getClinicalHistoryCatalog() != null ?

--- a/src/main/java/edu/mx/unsis/unsiSmile/mappers/students/GroupMapper.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/mappers/students/GroupMapper.java
@@ -31,7 +31,7 @@ public class GroupMapper implements BaseMapper<GroupResponse, GroupRequest, Grou
     public GroupResponse toDto(GroupModel entity) {
         return GroupResponse.builder()
                 .idGroup(entity.getIdGroup())
-                .groupName(formatGroupName(entity))
+                .groupName(entity.getGroupName())
                 .career(careerMapper.toDto(entity.getCareer()))
                 .semester(semesterMapper.toDto(entity.getSemester()))
                 .build();
@@ -47,12 +47,5 @@ public class GroupMapper implements BaseMapper<GroupResponse, GroupRequest, Grou
     @Override
     public void updateEntity(GroupRequest request, GroupModel entity) {
         entity.setGroupName(request.getGroupName());
-    }
-
-    private String formatGroupName(GroupModel entity) {
-        String baseName = entity.getSemesterNumber() + entity.getCareer().getIdCareer();
-        return (entity.getGroupName() != null && !entity.getGroupName().isEmpty())
-                ? baseName + "-" + entity.getGroupName()
-                : baseName;
     }
 }

--- a/src/main/java/edu/mx/unsis/unsiSmile/model/students/GroupModel.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/model/students/GroupModel.java
@@ -1,14 +1,7 @@
 package edu.mx.unsis.unsiSmile.model.students;
 
 import edu.mx.unsis.unsiSmile.model.utils.AuditModel;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
@@ -38,4 +31,12 @@ public class GroupModel extends AuditModel {
     @ManyToOne
     @JoinColumn(name = "fk_semester")
     private SemesterModel semester;
+
+    @Transient
+    public String getGroupName() {
+        String baseName = semesterNumber + career.getIdCareer();
+        return (groupName != null && !groupName.isEmpty())
+                ? baseName + "-" + groupName
+                : baseName;
+    }
 }


### PR DESCRIPTION
…s detalles del tratamiento

Los cambios en la estructura de la respuesta involucra los siguientes endpoints
![image](https://github.com/user-attachments/assets/b655a827-6611-40c2-8bbf-056336eabd02)

![image](https://github.com/user-attachments/assets/af024149-8974-49ff-9ee3-60babd5609eb)

![image](https://github.com/user-attachments/assets/7280992c-b02b-4b0e-b6f2-21e9b04e063b)

La nueva estructura es

```json
{
  "idTreatmentDetail": 0,
  "startDate": "2025-05-19T02:38:51.852Z",
  "endDate": "2025-05-19T02:38:51.852Z",
  "status": "string",
  "patient": {
    "id": "string",
    "name": "string",
    "medicalRecordNumber": 0,
    "idPatientMedicalRecord": 0
  },
  "professor": {
    "id": "string",
    "name": "string"
  },
  "student": {
    "id": "string",
    "name": "string",
    "idGroup": 0,
    "group": "string"
  },
  "treatment": {
    "idTreatment": 0,
    "name": "string",
    "treatmentScope": {
      "idScopeTreatment": 0,
      "name": "string"
    },
    "cost": 0,
    "clinicalHistoryCatalogId": 0,
    "clinicalHistoryCatalogName": "string"
  },
  "teeth": [
    {
      "idDetailTooth": 0,
      "idTooth": "string"
    }
  ]
}
