### PR TITLE
feat: add treatment-based endpoints and update dental prophylaxis model

### DIFF
--- a/src/main/java/edu/mx/unsis/unsiSmile/common/ResponseMessages.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/common/ResponseMessages.java
@@ -342,8 +342,10 @@ public class ResponseMessages {
     public static final String DENTAL_PROPHYLAXIS_NOT_FOUND = "No se encontró la profilaxis dental con ID: ";
     public static final String FAILED_DELETE_DENTAL_PROPHYLAXIS = "Error al eliminar la profilaxis dental";
     public static final String DUPLICATE_ENTRY = "Entrada duplicada";
-    public static final String DENTAL_PROPHYLAXIS_NOT_FOUND_BY_SECTION = "No se encontró la profilaxis dental con el ID de la sección del formulario: ";
+    public static final String DENTAL_PROPHYLAXIS_NOT_FOUND_BY_TREATMENT = "No se encontró la profilaxis dental con el ID de tratamiento: %s";
     public static final String FAILED_FETCH_DENTAL_PROPHYLAXIS_BY_PATIENT = "Error al obtener la profilaxis dental por ID de paciente";
+    public static final String FAILED_FETCH_DENTAL_PROPHYLAXIS_BY_TREATMENT = "Error al obtener la profilaxis dental por ID de tratamiento: %s";
+
 
     public static final String INVALID_STATUS = "Estatus no válido: ";
 

--- a/src/main/java/edu/mx/unsis/unsiSmile/controller/medicalHistories/DentalProphylaxisController.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/controller/medicalHistories/DentalProphylaxisController.java
@@ -47,12 +47,21 @@ public class DentalProphylaxisController {
         return ResponseEntity.noContent().build();
     }
 
-    @GetMapping("/form-section/{formSectionId}/patient/{patientId}")
-    public ResponseEntity<DentalProphylaxisResponse> getDentalProphylaxisByFormSectionIdAndPatientId(@PathVariable Long formSectionId,
-                                                                                                     @PathVariable String patientId) {
-        DentalProphylaxisResponse dentalProphylaxisResponse = dentalProphylaxisService.getDentalProphylaxisByFormSectionId(formSectionId,
-                patientId);
-        return ResponseEntity.ok(dentalProphylaxisResponse);
+    @Operation(summary = "Obtener una lista paginada de profilaxis dental por tratamiento")
+    @GetMapping("/treatments/{idTreatment}")
+    public ResponseEntity<Page<DentalProphylaxisResponse>> getAllByTreatmentId(
+            @PathVariable Long idTreatment,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "false") boolean asc) {
+
+        Sort sort = asc ? Sort.by("createdAt").ascending() : Sort.by("createdAt").descending();
+        Pageable pageable = PageRequest.of(page, size, sort);
+
+        Page<DentalProphylaxisResponse> result = dentalProphylaxisService
+                .getDentalProphylaxisByTreatmentId(idTreatment, pageable);
+
+        return ResponseEntity.ok(result);
     }
 
     @GetMapping("/patients/{patientId}")

--- a/src/main/java/edu/mx/unsis/unsiSmile/controller/medicalHistories/FluorosisController.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/controller/medicalHistories/FluorosisController.java
@@ -46,7 +46,7 @@ public class FluorosisController {
         return ResponseEntity.noContent().build();
     }
 
-    @Operation(summary = "Obtener un registro de fluorosis por id de la sección del formulario y id de paciente")
+    @Operation(summary = "Obtener un registro de fluorosis por id del tratamiento")
     @GetMapping("/treatments/{idTreatment}")
     public ResponseEntity<FluorosisResponse> getFluorosisByTreatmentId(@PathVariable Long idTreatment) {
         FluorosisResponse fluorosisResponse = fluorosisService.getFluorosisByTreatmentId(idTreatment);

--- a/src/main/java/edu/mx/unsis/unsiSmile/dtos/request/medicalHistories/DentalProphylaxisRequest.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/dtos/request/medicalHistories/DentalProphylaxisRequest.java
@@ -20,17 +20,8 @@ public class DentalProphylaxisRequest {
     @NotNull(message = ResponseMessages.REQUEST_CANNOT_BE_NULL)
     private List<ToothRequest> theetProphylaxis;
 
-    @NotNull(message = ResponseMessages.PATIENT_ID_CANNOT_BE_NULL)
-    private String idPatient;
-
-    @NotNull(message = ResponseMessages.QUESTION_ID_CANNOT_BE_NULL)
-    private Long idQuestion;
-
-    @NotNull(message = ResponseMessages.CLINICAL_HISTORY_ID_CANNOT_BE_NULL)
-    private Long idPatientClinicalHistory;
-
-    @NotNull(message = ResponseMessages.FORM_SECTION_ID_CANNOT_BE_NULL)
-    private Long idFormSection;
+    @NotNull(message = ResponseMessages.NOT_NULL_TREATMENT_ID)
+    private Long idTreatmentDetail;
 
     @DecimalMin(value = "0.00", message = ResponseMessages.PERCENTAGE_MIN_VALUE_ERROR)
     @DecimalMax(value = "100.00", message = ResponseMessages.PERCENTAGE_MAX_VALUE_ERROR)

--- a/src/main/java/edu/mx/unsis/unsiSmile/mappers/medicalHistories/DentalProphylaxisMapper.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/mappers/medicalHistories/DentalProphylaxisMapper.java
@@ -3,14 +3,14 @@ package edu.mx.unsis.unsiSmile.mappers.medicalHistories;
 import edu.mx.unsis.unsiSmile.dtos.request.medicalHistories.*;
 import edu.mx.unsis.unsiSmile.dtos.response.medicalHistories.DentalProphylaxisResponse;
 import edu.mx.unsis.unsiSmile.mappers.BaseMapper;
-import edu.mx.unsis.unsiSmile.model.FormSectionModel;
 import edu.mx.unsis.unsiSmile.model.medicalHistories.DentalProphylaxisModel;
-import edu.mx.unsis.unsiSmile.model.medicalHistories.odontogram.*;
+import edu.mx.unsis.unsiSmile.model.medicalHistories.odontogram.ProphylaxisToothConditionAssignmentModel;
+import edu.mx.unsis.unsiSmile.model.medicalHistories.odontogram.ProphylaxisToothfaceConditionsAssignmentModel;
 import edu.mx.unsis.unsiSmile.model.medicalHistories.teeth.ToothConditionModel;
 import edu.mx.unsis.unsiSmile.model.medicalHistories.teeth.ToothFaceConditionModel;
 import edu.mx.unsis.unsiSmile.model.medicalHistories.teeth.ToothFaceModel;
 import edu.mx.unsis.unsiSmile.model.medicalHistories.teeth.ToothModel;
-import edu.mx.unsis.unsiSmile.model.patients.PatientModel;
+import edu.mx.unsis.unsiSmile.model.medicalHistories.treatments.TreatmentDetailModel;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
@@ -49,9 +49,9 @@ public class DentalProphylaxisMapper implements BaseMapper<DentalProphylaxisResp
 
     public static DentalProphylaxisModel toDentalProphylaxisModel(DentalProphylaxisRequest dto) {
         DentalProphylaxisModel dentalProphylaxisModel = DentalProphylaxisModel.builder()
-                .patient(PatientModel.builder().idPatient(dto.getIdPatient()).build())
-                .percentage(dto.getPercentage())
-                .formSection(FormSectionModel.builder().idFormSection(dto.getIdFormSection()).build())
+                .treatmentDetail(TreatmentDetailModel.builder()
+                        .idTreatmentDetail(dto.getIdTreatmentDetail())
+                        .build())
                 .build();
 
         List<ProphylaxisToothConditionAssignmentModel> toothProphylaxisAssignments = dto.getTheetProphylaxis().stream()

--- a/src/main/java/edu/mx/unsis/unsiSmile/model/medicalHistories/DentalProphylaxisModel.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/model/medicalHistories/DentalProphylaxisModel.java
@@ -1,9 +1,8 @@
 package edu.mx.unsis.unsiSmile.model.medicalHistories;
 
-import edu.mx.unsis.unsiSmile.model.FormSectionModel;
 import edu.mx.unsis.unsiSmile.model.medicalHistories.odontogram.ProphylaxisToothConditionAssignmentModel;
 import edu.mx.unsis.unsiSmile.model.medicalHistories.odontogram.ProphylaxisToothfaceConditionsAssignmentModel;
-import edu.mx.unsis.unsiSmile.model.patients.PatientModel;
+import edu.mx.unsis.unsiSmile.model.medicalHistories.treatments.TreatmentDetailModel;
 import edu.mx.unsis.unsiSmile.model.utils.AuditModel;
 import jakarta.persistence.*;
 import lombok.*;
@@ -17,9 +16,7 @@ import java.util.List;
 @NoArgsConstructor
 @Builder
 @Entity
-@Table(name = "dental_prophylaxis", uniqueConstraints = {
-        @UniqueConstraint(columnNames = {"fk_patient", "fk_form_section"})
-})
+@Table(name = "dental_prophylaxis")
 public class DentalProphylaxisModel extends AuditModel {
 
     @Id
@@ -28,12 +25,8 @@ public class DentalProphylaxisModel extends AuditModel {
     private Long idDentalProphylaxis;
 
     @ManyToOne
-    @JoinColumn(name = "fk_patient", referencedColumnName = "id_patient")
-    private PatientModel patient;
-
-    @ManyToOne
-    @JoinColumn(name = "fk_form_section", referencedColumnName = "id_form_section")
-    private FormSectionModel formSection;
+    @JoinColumn(name = "fk_treatment_detail", referencedColumnName = "id_treatment_detail")
+    private TreatmentDetailModel treatmentDetail;
 
     @OneToMany(mappedBy = "dentalProphylaxis", cascade = CascadeType.MERGE, orphanRemoval = true)
     private List<ProphylaxisToothConditionAssignmentModel> toothConditionAssignments;

--- a/src/main/java/edu/mx/unsis/unsiSmile/repository/medicalHistories/IDentalProphylaxisRepository.java
+++ b/src/main/java/edu/mx/unsis/unsiSmile/repository/medicalHistories/IDentalProphylaxisRepository.java
@@ -11,7 +11,6 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface IDentalProphylaxisRepository extends JpaRepository<DentalProphylaxisModel, Long> {
@@ -22,8 +21,9 @@ public interface IDentalProphylaxisRepository extends JpaRepository<DentalProphy
     @Query("SELECT ptfca FROM ProphylaxisToothfaceConditionsAssignmentModel ptfca WHERE ptfca.dentalProphylaxis.idDentalProphylaxis = :prophylaxisId")
     List<ProphylaxisToothfaceConditionsAssignmentModel> findToothFaceConditionsAssignmentByProphylaxisId(Long prophylaxisId);
 
-    @Query("SELECT dp FROM DentalProphylaxisModel dp WHERE dp.formSection.idFormSection = :formSectionId AND dp.patient.idPatient = :patientId")
-    Optional<DentalProphylaxisModel> findByFormSectionIdAndPatientId(@Param("formSectionId") Long formSectionId, @Param("patientId") String patientId);
+    @Query("SELECT dp FROM DentalProphylaxisModel dp WHERE dp.treatmentDetail.idTreatmentDetail = :treatmentId ORDER BY dp.createdAt DESC")
+    Page<DentalProphylaxisModel> findByTreatmentId(@Param("treatmentId") Long treatmentId, Pageable pageable);
 
-    Page<DentalProphylaxisModel> findByPatient_IdPatientOrderByCreatedAtDesc(String patientId, Pageable pageable);
+    @Query("SELECT dp FROM DentalProphylaxisModel dp WHERE dp.treatmentDetail.patientClinicalHistory.patient.idPatient = :patientId ORDER BY dp.createdAt DESC")
+    Page<DentalProphylaxisModel> findByPatientId(String patientId, Pageable pageable);
 }

--- a/src/main/resources/db/migration/V0.0.19__changelog.sql
+++ b/src/main/resources/db/migration/V0.0.19__changelog.sql
@@ -18,16 +18,14 @@ values ("Marcado");
 -- Profilaxis dental
 CREATE TABLE dental_prophylaxis (
     id_dental_prophylaxis BIGINT AUTO_INCREMENT PRIMARY KEY,
-    fk_patient CHAR(36) NOT NULL,
-    fk_form_section BIGINT NOT NULL,
+    fk_treatment_detail BIGINT(20) NOT NULL,
     percentage DECIMAL(5, 2) NOT NULL,
     created_at DATETIME(6) DEFAULT NULL,
     created_by VARCHAR(255) DEFAULT NULL,
     status_key VARCHAR(255) DEFAULT NULL,
     updated_at DATETIME(6) DEFAULT NULL,
     updated_by VARCHAR(255) DEFAULT NULL,
-    CONSTRAINT FK_dental_prophylaxis_patients FOREIGN KEY (fk_patient) REFERENCES patients (id_patient),
-    CONSTRAINT FK_dental_prophylaxis_form_sections FOREIGN KEY (fk_form_section) REFERENCES form_sections (id_form_section)
+    FOREIGN KEY (fk_treatment_detail) REFERENCES treatment_details (id_treatment_detail)
 ) ENGINE = InnoDB DEFAULT CHARSET = utf8mb4 COLLATE = utf8mb4_general_ci;
 
 CREATE TABLE prophylaxis_tooth_condition_assignments (


### PR DESCRIPTION
Se actualiza el model de profilaxis así como la migración, se eliminan campos innecesarios y se actualiza las clases relacionadas
Se cambia el endpoint para consultar ahora las profilaxis por tratamiento de un paciente
![image](https://github.com/user-attachments/assets/09693fe2-f7c1-41f7-a359-9277f675f145)

nuevo request para crear una profilaxis ligado a un tratamiento
```json
{
  "theetProphylaxis": [
    {
      "idTooth": 0,
      "conditions": [
        {
          "idCondition": 0
        }
      ],
      "faces": [
        {
          "idFace": 0,
          "conditions": [
            {
              "idToothFaceCondition": 0,
              "description": "string"
            }
          ]
        }
      ]
    }
  ],
  "idTreatmentDetail": 0,
  "percentage": 100
}